### PR TITLE
Add title to db query

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -53,6 +53,10 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== "undefined") {
+    query.title = { $regex: `[A-Za-z0-9\W]*(${req.query.title})[A-Za-z0-9\W]*` }
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null


### PR DESCRIPTION
# Description

Include `title` in the db query to get items based on sent title. API searches to documents with title which includes the sent `title` text.

Changes to API:
API now takes a query called `title`
```
curl --location --request GET 'http://localhost:3000/api/items?title=title' \
--header 'Content-Type: application/json' \
--header 'X-Requested-With: XMLHttpRequest'
```
